### PR TITLE
Use shared build and cache dirs from host system

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Install dependencies: `brew install gitlab-runner daemonize cirruslabs/cli/tart`
 Ensure your host system has an SSH private key. If not, create one using `ssh-keygen -t ed25519`.
 
 ## Configurations
-- The image can be selected using Gitlab-CI's `image:` tag. Choose a different tart image, e.g. from https://github.com/orgs/cirruslabs/packages?tab=packages&q=macos. The current default is `ghcr.io/cirruslabs/macos-monterey-xcode:14`.
+- The image can be selected using Gitlab-CI's `image:` tag. Choose a different tart image, e.g. from https://github.com/orgs/cirruslabs/packages?tab=packages&q=macos. The current default is `ghcr.io/cirruslabs/macos-ventura-xcode:14.2`.

--- a/base.sh
+++ b/base.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 VM_ID="runner-$CUSTOM_ENV_CI_RUNNER_ID-project-$CUSTOM_ENV_CI_PROJECT_ID-concurrent-$CUSTOM_ENV_CI_CONCURRENT_PROJECT_ID-job-$CUSTOM_ENV_CI_JOB_ID"
-VM_IMAGE_FALLBACK="${CUSTOM_ENV_TART_IMAGE:-ghcr.io/cirruslabs/macos-monterey-xcode:14}" # this is left for compatibility with previous versions
+VM_IMAGE_FALLBACK="${CUSTOM_ENV_TART_IMAGE:-ghcr.io/cirruslabs/macos-ventura-xcode:14.2}" # this is left for compatibility with previous versions
 VM_IMAGE="${CUSTOM_ENV_CI_JOB_IMAGE:-$VM_IMAGE_FALLBACK}"
 
 VM_USER="admin"

--- a/gitlab-runner-example-config.toml
+++ b/gitlab-runner-example-config.toml
@@ -25,3 +25,4 @@ check_interval = 0
     cleanup_exec = "/Users/ci/gitlab-runner-tart/cleanup.sh"
   [runners.feature_flags]
     FF_RESOLVE_FULL_TLS_CHAIN = false
+    FF_ENABLE_JOB_CLEANUP = true

--- a/gitlab-runner-example-config.toml
+++ b/gitlab-runner-example-config.toml
@@ -12,8 +12,9 @@ check_interval = 0
   token_obtained_at = 2022-10-03T10:27:18Z
   token_expires_at = 0001-01-01T00:00:00Z
   executor = "custom"
-  builds_dir = "/Users/admin/builds"
-  cache_dir = "/Users/admin/cache"
+  builds_dir = "/Volumes/My Shared Files/builds"
+  cache_dir = "/Volumes/My Shared Files/cache"
+  builds_dir_is_shared = true
   [runners.custom_build_dir]
   [runners.cache]
     [runners.cache.s3]

--- a/prepare.sh
+++ b/prepare.sh
@@ -14,8 +14,14 @@ tart clone "$VM_IMAGE" "$VM_ID"
 # Update VM configuration
 tart set "$VM_ID" --cpu 4 --memory 8192
 
+# Ensure shared directories exist before starting a VM
+mkdir -p ~/{builds,cache}
+
 # Run the VM in background
-daemonize $(brew --prefix)/bin/tart run "$VM_ID" --no-graphics
+daemonize $(brew --prefix)/bin/tart run "$VM_ID" \
+    --no-graphics \
+    --dir=builds:~/builds \
+    --dir=cache:~/cache
 
 # Wait for VM to get IP
 echo 'Waiting for VM to get IP'


### PR DESCRIPTION
This is an implementation for mounting host directories as mentioned in #3.

Since the side effects of performance are not yet known to me, I'll need to further test this in a real world application. Our own internal CI needs adjustments to use this but could be a good performance indicator.